### PR TITLE
Pagination, autocomplete, filtering by workspace

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,7 @@
         "require-path-exists",
     ],
     "rules": {
-        "indent": [2, 2],
+        "indent": [2, 2, { "MemberExpression": "off" }],
 
         // Relax, React!
         "react/jsx-filename-extension": "off",
@@ -25,6 +25,7 @@
         "react/prop-types": "off",
         "react/forbid-prop-types": "off",
         "react/no-children-prop": "off",
+        "react/jsx-props-no-spreading": "off",
 
         // TODO Fix a11y issues
         "jsx-a11y/no-static-element-interactions": "off",

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
+        "@material-ui/lab": "*",
         "core-js": "^3.9.1",
         "jsonapi-react": "^0.0.24",
         "jss-rtl": "^0.3.0",
@@ -2671,6 +2672,32 @@
       },
       "peerDependencies": {
         "@material-ui/core": "^4.0.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@material-ui/lab": {
+      "version": "4.0.0-alpha.57",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz",
+      "integrity": "sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw==",
+      "dependencies": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.9.10",
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
@@ -21235,6 +21262,18 @@
       "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
       "requires": {
         "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.57",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz",
+      "integrity": "sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@material-ui/styles": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "*",
     "core-js": "^3.9.1",
     "jsonapi-react": "^0.0.24",
     "jss-rtl": "^0.3.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { IntlProvider, FormattedMessage } from 'react-intl';
 import {
   makeStyles,
@@ -90,7 +90,8 @@ function AsyncIntlProvider({ children }) {
 
 function App() {
   const classes = useStyles();
-  const [similarity, setSimilarity] = React.useState(90);
+  const [similarity, setSimilarity] = useState(90);
+  const [workspaces, setWorkspaces] = useState([]);
 
   const muiTheme = createMuiTheme({
     palette: {
@@ -125,8 +126,10 @@ function App() {
                   </Typography>
                 </Toolbar>
               </AppBar>
-              <Sidebar similarity={similarity} setSimilarity={setSimilarity} />
-              <Search similarity={similarity} />
+              <Sidebar
+                {...{ similarity, setSimilarity, workspaces, setWorkspaces }}
+              />
+              <Search {...{ similarity, workspaces }} />
             </div>
           </ThemeProvider>
         </StylesProvider>

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -9,16 +9,14 @@ import {
   ListItemIcon,
   Checkbox,
   Collapse,
-  TextField,
-  InputAdornment,
   Typography,
   CircularProgress,
 } from '@material-ui/core';
 import {
-  Search as SearchIcon,
   ExpandLess,
   ExpandMore,
 } from '@material-ui/icons';
+import FilterAutocomplete from './FilterAutocomplete';
 
 const useStyles = makeStyles((theme) => ({
   loading: {
@@ -35,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
 function Filter(props) {
   const classes = useStyles();
   const [open, setOpen] = React.useState(true);
-  const { query, search, items, header } = props;
+  const { query, items, header, setValue, value } = props;
 
   const handleClick = () => {
     setOpen(!open);
@@ -57,23 +55,13 @@ function Filter(props) {
           className={`${classes.error} filter-error-message`}
           variant="h6"
         >
-          {`Error ${error.status} fetching organizations: ${error.title}`}
+          {`Error ${error.status} fetching items: ${error.title}`}
         </Typography>
       );
     } else {
-      element = data.map((workspace, index) => (
-        <ListItem key={workspace.id} button className="query-item">
-          <ListItemIcon>
-            <Checkbox
-              edge="start"
-              checked={false}
-              tabIndex={-1}
-              disableRipple
-            />
-          </ListItemIcon>
-          <ListItemText id={index} primary={workspace.name} />
-        </ListItem>
-      ));
+      element = (
+        <FilterAutocomplete data={data} setValue={setValue} value={value} />
+      );
     }
 
     return (
@@ -91,45 +79,31 @@ function Filter(props) {
         {open ? <ExpandLess /> : <ExpandMore />}
       </ListItem>
       <Collapse in={open} timeout="auto" unmountOnExit>
-        {search ? (
-          <TextField
-            type="search"
-            id="search"
-            variant="outlined"
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon />
-                </InputAdornment>
-              ),
-            }}
-          />
-        ) : null}
         <List component="div" disablePadding dense>
           {items
             ? items
-              .reduce((acc, cur) => acc.concat('|').concat(cur))
-              .map((text, index) =>
-                // Disabling react index-key rule because we are dividing
-                // up a simple array.
-                /* eslint-disable react/no-array-index-key */
-                text === '|' ? (
-                  <Divider key={index} className="divider" />
-                ) : (
-                  <ListItem button key={index} className="item">
-                    <ListItemIcon>
-                      <Checkbox
-                        edge="start"
-                        checked={false}
-                        tabIndex={-1}
-                        disableRipple
-                      />
-                    </ListItemIcon>
-                    <ListItemText id={1} primary={text} />
-                  </ListItem>
-                  /* eslint-enable react/no-array-index-key */
-                ),
-              )
+                .reduce((acc, cur) => acc.concat('|').concat(cur))
+                .map((text, index) =>
+                  // Disabling react index-key rule because we are dividing
+                  // up a simple array.
+                  /* eslint-disable react/no-array-index-key */
+                  text === '|' ? (
+                    <Divider key={index} className="divider" />
+                  ) : (
+                    <ListItem button key={index} className="item">
+                      <ListItemIcon>
+                        <Checkbox
+                          edge="start"
+                          checked={false}
+                          tabIndex={-1}
+                          disableRipple
+                        />
+                      </ListItemIcon>
+                      <ListItemText id={1} primary={text} />
+                    </ListItem>
+                    /* eslint-enable react/no-array-index-key */
+                  ),
+                )
             : null}
           {query ? <QueryItems query={query} /> : null}
         </List>
@@ -140,13 +114,11 @@ function Filter(props) {
 
 Filter.defaultProps = {
   query: undefined,
-  search: false,
   items: undefined,
 };
 
 Filter.propTypes = {
   query: PropTypes.object,
-  search: PropTypes.bool,
   items: PropTypes.array,
 };
 

--- a/src/Filter.test.js
+++ b/src/Filter.test.js
@@ -25,46 +25,6 @@ describe('<Filter />', () => {
     expect(wrapper.find('hr.divider').length).toBe(2);
   });
 
-  it('renders results of a queried list', () => {
-    const data = [
-      {
-        id: '1',
-        name: 'Meedan',
-        slug: 'meedan',
-      },
-      {
-        id: '34',
-        name: 'Workspace Two',
-        slug: 'workspace-two',
-      },
-      {
-        id: '35',
-        name: 'Workspace Three',
-        slug: 'workspace-three',
-      },
-    ];
-    const query = {
-      isLoading: false,
-      isFetching: false,
-      data,
-    };
-    const wrapper = mountWithIntl(
-      <Filter
-        header={<FormattedMessage id="test.message" defaultMessage="Test" />}
-        items={items}
-        query={query}
-      />,
-    );
-    expect(wrapper.props().items).toEqual(items);
-    // Check for hard-coded items
-    expect(wrapper.find('.item').first().text()).toEqual('Item 1A');
-    expect(wrapper.find('.item').last().text()).toEqual('Item 3C');
-    // Look for fetched item
-    expect(wrapper.find('.query-item').last().text()).toEqual(
-      'Workspace Three',
-    );
-  });
-
   it('renders hard coded items and a loading spinner while query is running', () => {
     const query = {
       isLoading: true,

--- a/src/FilterAutocomplete.js
+++ b/src/FilterAutocomplete.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TextField, makeStyles } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import { Close } from '@material-ui/icons';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: '100%',
+    '& > * + *': {
+      marginTop: theme.spacing(3),
+    },
+    '& .MuiAutocomplete-tag': {
+      margin: theme.spacing(0.25),
+      height: '22px',
+      fontSize: '0.75rem',
+      backgroundColor: '#2f80ed',
+      color: 'white',
+      '& .MuiChip-label': {
+        padding: '2px 6px 2px 8px',
+        fontWeight: 600,
+      },
+      '& .MuiChip-deleteIcon': {
+        margin: '0px 2px 0px -6px',
+        color: 'white',
+      },
+    },
+  },
+}));
+
+function FilterAutocomplete(props) {
+  const classes = useStyles();
+  const { data, setValue, value } = props;
+
+  function handleChange(e, selectedValues) {
+    setValue(selectedValues);
+  }
+
+  return (
+    <div className={classes.root}>
+      <Autocomplete
+        multiple
+        id="tags-outlined"
+        options={data}
+        ChipProps={{ deleteIcon: <Close /> }}
+        getOptionLabel={(option) => option.name}
+        onChange={handleChange}
+        defaultValue={[]}
+        value={value}
+        filterSelectedOptions
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            variant="outlined"
+            label="Select specific publishers"
+          />
+        )}
+      />
+    </div>
+  );
+}
+
+FilterAutocomplete.defaultProps = {
+  data: undefined,
+  setValue: undefined,
+  value: [],
+};
+
+FilterAutocomplete.propTypes = {
+  data: PropTypes.array,
+  setValue: PropTypes.func,
+  value: PropTypes.array,
+};
+
+export default FilterAutocomplete;

--- a/src/FilterAutocomplete.test.js
+++ b/src/FilterAutocomplete.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import FilterAutocomplete from './FilterAutocomplete.js';
+import { mountWithIntl } from './helpers/intl-enzyme-test-helper';
+
+const data = [
+  { id: 1, name: 'first' },
+  { id: 2, name: 'second' },
+  { id: 3, name: 'third' },
+  { id: 4, name: 'fourth' },
+];
+
+test('FilterAutocomplete renders', () => {
+  mountWithIntl(
+    <FilterAutocomplete data={data} setValue={jest.fn()} value={[]} />,
+  );
+});

--- a/src/Search.js
+++ b/src/Search.js
@@ -33,15 +33,18 @@ const useStyles = makeStyles((theme) => ({
 function Search(props) {
   const classes = useStyles();
   const { similarity, workspaces } = props;
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState({
+    data: [],
+    meta: { 'record-count': 0 },
+  });
   const [pageNumber, setPageNumber] = useState(0);
   const [confirmedText, setConfirmedText] = useState('');
   const [error, setError] = useState({ hasError: false, message: '' });
-  const [rowsPerPage, setRowsPerPage] = React.useState(2);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
   const client = useClient();
 
   async function getData() {
-    const { data } = await client.fetch([
+    const data = await client.fetch([
       'reports',
       {
         filter: {

--- a/src/Search.test.js
+++ b/src/Search.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Search from './Search';
+import 'regenerator-runtime/runtime';
 import { mountWithIntl } from './helpers/intl-enzyme-test-helper';
 
 describe('<Search />', () => {
@@ -12,6 +13,6 @@ describe('<Search />', () => {
       .find('input')
       .at(0)
       .simulate('change', { target: { name: 'search', value: 'Search text' } });
-    expect(wrapper.find('input').props().value).toEqual('Search text');
+    expect(wrapper.find('input').at(0).props().value).toEqual('Search text');
   });
 });

--- a/src/SearchResults.js
+++ b/src/SearchResults.js
@@ -6,6 +6,14 @@ import {
   Card,
   CardContent,
   Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Paper,
 } from '@material-ui/core';
 import { useIntl } from 'react-intl';
 
@@ -20,6 +28,19 @@ const useStyles = makeStyles((theme) => ({
   },
   error: {
     color: 'red',
+  },
+  root: {
+    width: '100%',
+  },
+  container: {
+    height: 700,
+    maxHeight: 700,
+  },
+  thumbnail: {
+    padding: theme.spacing(1),
+    maxHeight: '200px',
+    maxWidth: '200px',
+    float: 'left',
   },
 }));
 
@@ -47,34 +68,149 @@ function SearchError(props) {
 function SearchResults(props) {
   const classes = useStyles();
   const intl = useIntl();
-  const { results, error } = props;
-  if (!Array.isArray(results) && !error.hasError) {
+  const {
+    results,
+    error,
+    rowsPerPage,
+    setRowsPerPage,
+    pageNumber,
+    setPageNumber,
+  } = props;
+  if (!Array.isArray(results)) {
     error.hasError = true;
     error.message = intl.formatMessage({
       id: 'search.genericError',
       defaultMessage: 'Something went wrong with your search.',
-      description: 'This message appears when we don\'t know why an error has occurred during a search. Otherwise we show the real error.',
+      description:
+        "This message appears when we don't know why an error has occurred during a search. Otherwise we show the real error.",
     });
   }
+  if (error.hasError) {
+    return <SearchError error={error} />;
+  }
+  const columns = [
+    {
+      id: 'report',
+      label: 'Report',
+      minWidth: 170,
+      align: 'left',
+    },
+    {
+      id: 'published',
+      label: 'Published',
+      minWidth: 50,
+      align: 'left',
+      format: (value) => {
+        const d = new Date(value * 1000);
+        const formatted = new Intl.DateTimeFormat().format(d).toString();
+        return formatted;
+      },
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      apiField: 'report-rating',
+      minWidth: 100,
+      align: 'left',
+    },
+    {
+      id: 'score',
+      label: 'Score',
+      minWidth: 100,
+      align: 'left',
+    },
+    {
+      id: 'url',
+      label: 'Published article',
+      apiField: 'article-link',
+      minWidth: 100,
+      align: 'left',
+      format: (value) => <a href={value}>{value}</a>,
+    },
+    {
+      id: 'sent',
+      label: 'Sent',
+      apiField: 'requests',
+      minWidth: 100,
+      align: 'left',
+    },
+  ];
+
+  const handleChangePage = (event, newPage) => {
+    setPageNumber(newPage);
+  };
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(+event.target.value);
+    setPageNumber(0);
+  };
   return (
-    <>
-      {error.hasError ? (
-        <SearchError error={error} />
-      ) : (
-        results.map((report) => (
-          <Grid item xs={12} key={report.id} className={classes.results}>
-            <Card variant="outlined">
-              <CardContent>
-                <Typography className={classes.title} variant="h6">
-                  Report Title
-                </Typography>
-                <Typography>{report.title}</Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))
-      )}
-    </>
+    <Paper className={classes.root}>
+      <TableContainer className={classes.container}>
+        <Table stickyHeader aria-label="sticky table">
+          <TableHead>
+            <TableRow>
+              {columns.map((column) => (
+                <TableCell
+                  key={column.id}
+                  align={column.align}
+                  style={{ minWidth: column.minWidth }}
+                >
+                  {column.label}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {results.map((row) => (
+              <TableRow hover role="checkbox" tabIndex={-1} key={row.id}>
+                {columns.map((column) => {
+                  let result;
+                  if (column.id === 'report') {
+                    result = (
+                      <TableCell key={column.id} align={column.align}>
+                        {row['lead-image'] ? (
+                          <img
+                            className={classes.thumbnail}
+                            src={row['lead-image']}
+                            alt={row.title}
+                          />
+                        ) : null}
+                        <Typography variant="h6">{row.title}</Typography>
+                        <Typography variant="body2">
+                          {row.description}
+                        </Typography>
+                      </TableCell>
+                    );
+                  } else {
+                    let value;
+                    if (column.apiField) {
+                      value = row[column.apiField];
+                    } else {
+                      value = row[column.id];
+                    }
+                    result = (
+                      <TableCell key={column.id} align={column.align}>
+                        {value && column.format ? column.format(value) : value}
+                      </TableCell>
+                    );
+                  }
+                  return result;
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[2, 10, 50]}
+        component="div"
+        count={10}
+        rowsPerPage={rowsPerPage}
+        page={pageNumber}
+        onChangePage={handleChangePage}
+        onChangeRowsPerPage={handleChangeRowsPerPage}
+      />
+    </Paper>
   );
 }
 

--- a/src/SearchResults.js
+++ b/src/SearchResults.js
@@ -76,7 +76,7 @@ function SearchResults(props) {
     pageNumber,
     setPageNumber,
   } = props;
-  if (!Array.isArray(results)) {
+  if (!(results.meta && results.data)) {
     error.hasError = true;
     error.message = intl.formatMessage({
       id: 'search.genericError',
@@ -161,7 +161,7 @@ function SearchResults(props) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {results.map((row) => (
+            {results.data.map((row) => (
               <TableRow hover role="checkbox" tabIndex={-1} key={row.id}>
                 {columns.map((column) => {
                   let result;
@@ -204,7 +204,7 @@ function SearchResults(props) {
       <TablePagination
         rowsPerPageOptions={[2, 10, 50]}
         component="div"
-        count={10}
+        count={results.meta['record-count']}
         rowsPerPage={rowsPerPage}
         page={pageNumber}
         onChangePage={handleChangePage}
@@ -215,7 +215,7 @@ function SearchResults(props) {
 }
 
 SearchResults.propTypes = {
-  results: PropTypes.array.isRequired,
+  results: PropTypes.object.isRequired,
   error: PropTypes.object.isRequired,
 };
 

--- a/src/SearchResults.test.js
+++ b/src/SearchResults.test.js
@@ -5,14 +5,26 @@ import { mountWithIntl } from './helpers/intl-enzyme-test-helper';
 describe('<SearchResults />', () => {
   it('renders the basic search', () => {
     const wrapper = mountWithIntl(
-      <SearchResults error={{}} results={{ data: [], meta: {'record-count': 0}}} locale="en" pageNumber={0} rowsPerPage={2} />,
+      <SearchResults
+        error={{}}
+        results={{ data: [], meta: { 'record-count': 0 } }}
+        locale="en"
+        pageNumber={0}
+        rowsPerPage={2}
+      />,
     );
     expect(wrapper.props().error).toEqual({});
   });
   it('renders an error message when passed incorrect object results', () => {
     const results = {};
     const wrapper = mountWithIntl(
-      <SearchResults error={{}} results={results} locale="en" pageNumber={0} rowsPerPage={2} />,
+      <SearchResults
+        error={{}}
+        results={results}
+        locale="en"
+        pageNumber={0}
+        rowsPerPage={2}
+      />,
     );
     expect(
       wrapper.find('.MuiTypography-root.search-error-message').length,
@@ -24,7 +36,13 @@ describe('<SearchResults />', () => {
       message: 'This error message was returned from the API',
     };
     const wrapper = mountWithIntl(
-      <SearchResults error={error} results={{ data: [], meta: {'record-count': 0}}} locale="en" pageNumber={0} rowsPerPage={2} />,
+      <SearchResults
+        error={error}
+        results={{ data: [], meta: { 'record-count': 0 } }}
+        locale="en"
+        pageNumber={0}
+        rowsPerPage={2}
+      />,
     );
     expect(
       wrapper.find('.MuiTypography-root.search-error-message').length,

--- a/src/SearchResults.test.js
+++ b/src/SearchResults.test.js
@@ -5,7 +5,7 @@ import { mountWithIntl } from './helpers/intl-enzyme-test-helper';
 describe('<SearchResults />', () => {
   it('renders the basic search', () => {
     const wrapper = mountWithIntl(
-      <SearchResults error={{}} results={[]} locale="en" />,
+      <SearchResults error={{}} results={[]} locale="en" pageNumber={0} rowsPerPage={2} />,
     );
     expect(wrapper.props().error).toEqual({});
   });
@@ -16,7 +16,7 @@ describe('<SearchResults />', () => {
     const errorFunction = console.error;
     console.error = jest.fn();
     const wrapper = mountWithIntl(
-      <SearchResults error={{}} results={results} locale="en" />,
+      <SearchResults error={{}} results={results} locale="en" pageNumber={0} rowsPerPage={2} />,
     );
     expect(
       wrapper.find('.MuiTypography-root.search-error-message').length,
@@ -30,7 +30,7 @@ describe('<SearchResults />', () => {
       message: 'This error message was returned from the API',
     };
     const wrapper = mountWithIntl(
-      <SearchResults error={error} results={[]} locale="en" />,
+      <SearchResults error={error} results={[]} locale="en" pageNumber={0} rowsPerPage={2} />,
     );
     expect(
       wrapper.find('.MuiTypography-root.search-error-message').length,

--- a/src/SearchResults.test.js
+++ b/src/SearchResults.test.js
@@ -5,24 +5,18 @@ import { mountWithIntl } from './helpers/intl-enzyme-test-helper';
 describe('<SearchResults />', () => {
   it('renders the basic search', () => {
     const wrapper = mountWithIntl(
-      <SearchResults error={{}} results={[]} locale="en" pageNumber={0} rowsPerPage={2} />,
+      <SearchResults error={{}} results={{ data: [], meta: {'record-count': 0}}} locale="en" pageNumber={0} rowsPerPage={2} />,
     );
     expect(wrapper.props().error).toEqual({});
   });
-  it('renders an error message when passed non-array results', () => {
-    const results = 'this is not an array';
-    // We are intentionally sending bad data that will throw a PropType warning with this test. So here we mock console.error temporarily, because we don't want the PropType warning polluting our test log: we know it's supposed to happen. We also disable eslint warnings for accessing the console object.
-    /* eslint-disable no-console */
-    const errorFunction = console.error;
-    console.error = jest.fn();
+  it('renders an error message when passed incorrect object results', () => {
+    const results = {};
     const wrapper = mountWithIntl(
       <SearchResults error={{}} results={results} locale="en" pageNumber={0} rowsPerPage={2} />,
     );
     expect(
       wrapper.find('.MuiTypography-root.search-error-message').length,
     ).toEqual(1);
-    console.error = errorFunction;
-    /* eslint-enable no-console */
   });
   it('renders any error message returned from the API', () => {
     const error = {
@@ -30,7 +24,7 @@ describe('<SearchResults />', () => {
       message: 'This error message was returned from the API',
     };
     const wrapper = mountWithIntl(
-      <SearchResults error={error} results={[]} locale="en" pageNumber={0} rowsPerPage={2} />,
+      <SearchResults error={error} results={{ data: [], meta: {'record-count': 0}}} locale="en" pageNumber={0} rowsPerPage={2} />,
     );
     expect(
       wrapper.find('.MuiTypography-root.search-error-message').length,

--- a/src/Sidebar.js
+++ b/src/Sidebar.js
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
 
 function Sidebar(props) {
   const classes = useStyles();
-  const { similarity, setSimilarity } = props;
+  const { similarity, setSimilarity, workspaces, setWorkspaces } = props;
   function handleSimilarityTextFieldChange(e) {
     setSimilarity(e.target.value);
   }
@@ -114,7 +114,8 @@ function Sidebar(props) {
             }
             items={[['All'], ['Check workspaces', 'Non-Check workspaces']]}
             query={workspacesQuery}
-            search
+            setValue={setWorkspaces}
+            value={workspaces}
           />
           <Filter
             header={

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
       },
     ],
   },
-  mode: 'production',
+  mode: NODE_ENV,
   optimization: {
     splitChunks: {
       name: false,


### PR DESCRIPTION
* tweak eslint rules
* ignore `.env` file
* make webpack actually respect the `NODE_ENV` environment variable
* add the `material-ui/lab` package for `Autocomplete`
* create a `workspaces` state at the top level in the `App` component
  * `Sidebar` takes this and modifies the state based on user selection, propagates up to `App`, then back down to `Search` where queries are fired off (similar to how `similarity` propagates)
* add a `FilterAutocomplete` component that is a lightly modified version of `Autocomplete` in `material-ui`
* refactor how button presses work so we don't rerender the whole page every time a keypress happens in the main textinput
* pagination: we now get paged responses from the `reports` endpoint