### PR TITLE
ESLint warns when missing translation descriptions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,7 +75,7 @@
         "operator-linebreak": "off",
 
         // react-intl / formatjs rules
-        "formatjs/enforce-description": 1,
+        "formatjs/enforce-description": 2,
     },
     "overrides": [
         {

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
     },
     "plugins": [
         "require-path-exists",
+        "formatjs",
     ],
     "rules": {
         "indent": [2, 2, { "MemberExpression": "off" }],
@@ -72,6 +73,9 @@
         "implicit-arrow-linebreak": "off",
         "object-curly-newline": "off",
         "operator-linebreak": "off",
+
+        // react-intl / formatjs rules
+        "formatjs/enforce-description": 1,
     },
     "overrides": [
         {

--- a/localization/transifex/source.json
+++ b/localization/transifex/source.json
@@ -1,8 +1,10 @@
 {
   "filters.organizations": {
+    "developer_comment": "This is a heading that will be immediately followed by a list of known publishing organizations that the user can choose from.",
     "string": "Publishers"
   },
   "filters.type": {
+    "developer_comment": "This is a heading that will be immediately followed by a list of types of content (image, text, video) that the user can choose from.",
     "string": "Content Type"
   },
   "homepage.title": {
@@ -10,6 +12,7 @@
     "string": "Similarity Search Prototype"
   },
   "search.action": {
+    "developer_comment": "This is a verb that indicates the user is going to search a database for records based on a query they typed.",
     "string": "Search"
   },
   "search.genericError": {
@@ -17,6 +20,7 @@
     "string": "Something went wrong with your search."
   },
   "search.title": {
+    "developer_comment": "This is a message that appears above the search bar in the application. It is supposed to indicate what group of documents the user is about to search.",
     "string": "Report Database"
   },
   "sidebar.filters": {
@@ -28,6 +32,7 @@
     "string": "Similarity"
   },
   "test.message": {
+    "developer_comment": "test",
     "string": "Test"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^7.23.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-loader": "^4.0.2",
+        "eslint-plugin-formatjs": "^2.14.6",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.22.0",
@@ -2946,6 +2947,28 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-iacbaYN9IWWrGWTwlYLVOeUtN/e4cjN9Uh6v7Yo1Qa/vJzeSQeh10L/erBBSl53BTmbnQ07vsWp8mmNHGI4WbQ==",
+      "dev": true
+    },
+    "node_modules/@types/eslint": {
+      "version": "7.2.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
+      "integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -3178,6 +3201,105 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "dev": true,
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/visitor-keys": "3.10.1",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.0.11",
@@ -7407,6 +7529,85 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/eslint-plugin-formatjs": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.14.6.tgz",
+      "integrity": "sha512-+FQ+AD8dumAmuWHM0HoOqFHcmfSv+Ag3cQ73LH/6QRIX8AZiZbdc4oV3ZDHRaE9dQtp54L1VJhmi8TEsHGjzHQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "1.1.5",
+        "@formatjs/ts-transformer": "3.3.7",
+        "@types/emoji-regex": "^8.0.0",
+        "@types/eslint": "^7.2.0",
+        "@typescript-eslint/typescript-estree": "^3.6.0",
+        "emoji-regex": "^9.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.5.tgz",
+      "integrity": "sha512-dhRWSoPPw8PhB5tSOEP9Gi5XZNFC2IkfP95Va70ouIuED0wBlsU1WmO4jDHITL7/kSNqvzKFTT+2S+6jHPq6jw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-1.1.5.tgz",
+      "integrity": "sha512-TZC3Ac6zTZGlkPoOstJpllo0rkI60kYSOcyhv7zXcaqzAxgdY+6WK8D91x1O9Swy5Jk1PUQM1IAMdafxZoz+Zg==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.6.5",
+        "@formatjs/icu-skeleton-parser": "1.1.2",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.1.2.tgz",
+      "integrity": "sha512-R0hxPsnq9oOW50HnqKjzuqzUOEUWRdSqqt2wvLCwlFMEx6+MsLW35yzbB9fnxfRZ6vVnYO69TxBfXvvsK2VoUw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.6.5",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/@formatjs/ts-transformer": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.3.7.tgz",
+      "integrity": "sha512-njO4HMo0zGETY5cYz2ifsEO5FnZs+NyIUSXrGrcE0l9p188P5AIsJ+9HeK3ZGP6u/srtchBytIQFrvhskaQOzQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "1.1.5",
+        "tslib": "^2.1.0",
+        "typescript": "^4.0"
+      },
+      "peerDependencies": {
+        "ts-jest": "^26.4.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-formatjs/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "dev": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.22.1",
@@ -17808,6 +18009,21 @@
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -21444,6 +21660,28 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-iacbaYN9IWWrGWTwlYLVOeUtN/e4cjN9Uh6v7Yo1Qa/vJzeSQeh10L/erBBSl53BTmbnQ07vsWp8mmNHGI4WbQ==",
+      "dev": true
+    },
+    "@types/eslint": {
+      "version": "7.2.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
+      "integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -21675,6 +21913,71 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
+    },
+    "@typescript-eslint/types": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/visitor-keys": "3.10.1",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
     },
     "@vue/compiler-core": {
       "version": "3.0.11",
@@ -25366,6 +25669,76 @@
           "requires": {
             "find-up": "^2.1.0"
           }
+        }
+      }
+    },
+    "eslint-plugin-formatjs": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.14.6.tgz",
+      "integrity": "sha512-+FQ+AD8dumAmuWHM0HoOqFHcmfSv+Ag3cQ73LH/6QRIX8AZiZbdc4oV3ZDHRaE9dQtp54L1VJhmi8TEsHGjzHQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "1.1.5",
+        "@formatjs/ts-transformer": "3.3.7",
+        "@types/emoji-regex": "^8.0.0",
+        "@types/eslint": "^7.2.0",
+        "@typescript-eslint/typescript-estree": "^3.6.0",
+        "emoji-regex": "^9.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.5.tgz",
+          "integrity": "sha512-dhRWSoPPw8PhB5tSOEP9Gi5XZNFC2IkfP95Va70ouIuED0wBlsU1WmO4jDHITL7/kSNqvzKFTT+2S+6jHPq6jw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/icu-messageformat-parser": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-1.1.5.tgz",
+          "integrity": "sha512-TZC3Ac6zTZGlkPoOstJpllo0rkI60kYSOcyhv7zXcaqzAxgdY+6WK8D91x1O9Swy5Jk1PUQM1IAMdafxZoz+Zg==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.6.5",
+            "@formatjs/icu-skeleton-parser": "1.1.2",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/icu-skeleton-parser": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.1.2.tgz",
+          "integrity": "sha512-R0hxPsnq9oOW50HnqKjzuqzUOEUWRdSqqt2wvLCwlFMEx6+MsLW35yzbB9fnxfRZ6vVnYO69TxBfXvvsK2VoUw==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.6.5",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/ts-transformer": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.3.7.tgz",
+          "integrity": "sha512-njO4HMo0zGETY5cYz2ifsEO5FnZs+NyIUSXrGrcE0l9p188P5AIsJ+9HeK3ZGP6u/srtchBytIQFrvhskaQOzQ==",
+          "dev": true,
+          "requires": {
+            "@formatjs/icu-messageformat-parser": "1.1.5",
+            "tslib": "^2.1.0",
+            "typescript": "^4.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
         }
       }
     },
@@ -33532,6 +33905,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-loader": "^4.0.2",
+    "eslint-plugin-formatjs": "^2.14.6",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",

--- a/src/Filter.test.js
+++ b/src/Filter.test.js
@@ -13,7 +13,13 @@ describe('<Filter />', () => {
   it('renders the basic filter', () => {
     const wrapper = mountWithIntl(
       <Filter
-        header={<FormattedMessage id="test.message" defaultMessage="Test" />}
+        header={
+          <FormattedMessage
+            id="test.message"
+            defaultMessage="Test"
+            description="test"
+          />
+        }
         items={items}
       />,
     );
@@ -33,7 +39,13 @@ describe('<Filter />', () => {
     };
     const wrapper = mountWithIntl(
       <Filter
-        header={<FormattedMessage id="test.message" defaultMessage="Test" />}
+        header={
+          <FormattedMessage
+            id="test.message"
+            defaultMessage="Test"
+            description="test"
+          />
+        }
         items={items}
         query={query}
       />,
@@ -52,7 +64,13 @@ describe('<Filter />', () => {
     };
     const wrapper = mountWithIntl(
       <Filter
-        header={<FormattedMessage id="test.message" defaultMessage="Test" />}
+        header={
+          <FormattedMessage
+            id="test.message"
+            defaultMessage="Test"
+            description="test"
+          />
+        }
         items={items}
         query={query}
       />,

--- a/src/Search.js
+++ b/src/Search.js
@@ -96,6 +96,7 @@ function Search(props) {
               <FormattedMessage
                 id="search.title"
                 defaultMessage="Report Database"
+                description="This is a message that appears above the search bar in the application. It is supposed to indicate what group of documents the user is about to search."
               />
             </Typography>
           </Grid>
@@ -142,6 +143,8 @@ function SearchInput(props) {
           label={intl.formatMessage({
             id: 'search.action',
             defaultMessage: 'Search',
+            description:
+              'This is a verb that indicates the user is going to search a database for records based on a query they typed.',
           })}
           variant="outlined"
           value={searchText}
@@ -172,7 +175,7 @@ function SearchInput(props) {
           type="submit"
           onClick={() => setConfirmedText(searchText)}
         >
-          <FormattedMessage id="search.action" defaultMessage="Search" />
+          <FormattedMessage id="search.action" defaultMessage="Search" description="This is a verb that indicates the user is going to search a database for records based on a query they typed." />
         </Button>
       </Grid>
     </>

--- a/src/Sidebar.js
+++ b/src/Sidebar.js
@@ -109,6 +109,7 @@ function Sidebar(props) {
                 <FormattedMessage
                   id="filters.organizations"
                   defaultMessage="Publishers"
+                  description="This is a heading that will be immediately followed by a list of known publishing organizations that the user can choose from."
                 />
               </Typography>
             }
@@ -123,6 +124,7 @@ function Sidebar(props) {
                 <FormattedMessage
                   id="filters.type"
                   defaultMessage="Content Type"
+                  description="This is a heading that will be immediately followed by a list of types of content (image, text, video) that the user can choose from."
                 />
               </Typography>
             }


### PR DESCRIPTION
Installs the `eslint-plugin-formatjs` plugin and configures it to warn on lack of description.

For example, running the linter step now shows this:

![image](https://user-images.githubusercontent.com/266454/115299039-214bd300-a113-11eb-9e81-af7f64924107.png)

I have temporarily set it to "warning" instead of "error" because we aren't going to have 100% description coverage immediately, though we should strive for it. Once this project hits 100% I plan to enforce it as an error, which will cause CI to fail if there is no description.