### PR TITLE
Deploy fix to use production /dist build of check-search

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA"
   only:
     - develop
+    - deploy-fix-use-dist
 
 deploy_qa:
   image: python:3-alpine
@@ -42,6 +43,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA"
   only:
     - develop
+    - deploy-fix-use-dist
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA"
   only:
     - develop
-    - deploy-fix-use-dist
 
 deploy_qa:
   image: python:3-alpine
@@ -43,7 +42,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA"
   only:
     - develop
-    - deploy-fix-use-dist
 
 build_live:
   image: docker:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-l
 
 COPY --chown=search:search package.json package-lock.json ./
 RUN npm install $INSTALL_ARGS
-RUN if [[ "$INSTALL_ARGS" != "" ]]; then npm build; fi
+RUN if [[ "$INSTALL_ARGS" != "" ]]; then npm run build; fi
 
 # tx client
 RUN pip install --upgrade transifex-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-l
 
 COPY --chown=search:search package.json package-lock.json ./
 RUN npm install $INSTALL_ARGS
-RUN if [[ "$INSTALL_ARGS" != "" ]]; then npm run build; fi
 
 # tx client
 RUN pip install --upgrade transifex-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN groupadd -r search
 RUN useradd -ms /bin/bash -g search search
 RUN chown search:search .
 
-RUN apt-get update || : && apt-get install -y python python-pip jq unzip curl git
+RUN apt-get update || : && apt-get install -y python python-pip jq unzip curl git nginx
 
 # Due to the outdated version of awscli in upstream repos, manually install latest from Amazon.
 RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
@@ -22,6 +22,7 @@ RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-l
 
 COPY --chown=search:search package.json package-lock.json ./
 RUN npm install $INSTALL_ARGS
+RUN if [[ "$INSTALL_ARGS" != "" ]]; then npm build; fi
 
 # tx client
 RUN pip install --upgrade transifex-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-l
       rm -rf awscliv2.zip
 
 COPY --chown=search:search package.json package-lock.json ./
-RUN npm install $INSTALL_ARGS
+RUN npm install
+RUN npm run build
 
 # tx client
 RUN pip install --upgrade transifex-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-l
 
 COPY --chown=search:search package.json package-lock.json ./
 RUN npm install $INSTALL_ARGS
-RUN npm run build
 
 # tx client
 RUN pip install --upgrade transifex-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl --silent --show-error --fail "https://awscli.amazonaws.com/awscli-exe-l
       rm -rf awscliv2.zip
 
 COPY --chown=search:search package.json package-lock.json ./
-RUN npm install
+RUN npm install $INSTALL_ARGS
 RUN npm run build
 
 # tx client

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,6 +30,7 @@ fi
 if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   # Production entrypoint
   if [ ! -d dist ]; then
+    npm install $INSTALL_ARGS
     npm run build
   fi
   # this is a minimal node runtime, without most utilities.  compensate :)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,8 +29,10 @@ fi
 #
 if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   # Production entrypoint
+  #
   npm install
   npm run build
+  ls -l dist
   mv /var/www/html /var/www/prev-html
   ln -s /app/dist /var/www/html
   cat /etc/nginx/sites-available/default | sed 's/listen 80 default_server/listen 8001 default_server/' > /tmp/.tmpf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,18 +29,15 @@ fi
 #
 if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   # Production entrypoint
-  if [ ! -d dist ]; then
-    npm install
-    npm run build
-  fi
-  # this is a minimal node runtime, without most utilities.  compensate :)
-  if [ -f /var/www/html/index.nginx-debian.html ]; then
-    mv /var/www/html /var/www/prev-html
-    ln -s /app/dist /var/www/html
-    cat /etc/nginx/sites-available/default | sed 's/listen 80 default_server/listen 8001 default_server/' > /tmp/.tmpf
-    cat /tmp/.tmpf > /etc/nginx/sites-available/default
-    nginx -g 'daemon off;'
-  fi
+  npm install
+  npm run build
+  mv /var/www/html /var/www/prev-html
+  ln -s /app/dist /var/www/html
+  cat /etc/nginx/sites-available/default | sed 's/listen 80 default_server/listen 8001 default_server/' > /tmp/.tmpf
+  cat /tmp/.tmpf > /etc/nginx/sites-available/default
+  nginx -g 'daemon off;'
+  # add a post-exit sleep for debugging
+  sleep 3600
 else
   # Developer entrypoint:
   #

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,9 +30,7 @@ fi
 if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   # Production entrypoint
   if [ ! -d dist ]; then
-    npm install --save-dev webpack
-    npm install --save-dev webpack-cli
-    npm install $INSTALL_ARGS
+    npm install
     npm run build
   fi
   # this is a minimal node runtime, without most utilities.  compensate :)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,6 +30,8 @@ fi
 if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   # Production entrypoint
   if [ ! -d dist ]; then
+    npm install --save-dev webpack
+    npm install --save-dev webpack-cli
     npm install $INSTALL_ARGS
     npm run build
   fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,4 +25,20 @@ fi
 npm install
 # npm run test:lint
 # npm run test
-npm run start
+
+# NOTE: for a production environment (QA, Live) we serve content
+# via separate web server (nginx). Otherwise, run in development
+# mode directly.
+#
+if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
+  # this is a minimal node runtime, without most utilities.  compensate :)
+  if [ -f /var/www/html/index.nginx-debian.html ]; then
+    mv /var/www/html /var/www/prev-html
+    ln -s /app/dist /var/www/html
+    cat /etc/nginx/sites-available/default | sed 's/listen 80 default_server/listen 8001 default_server/' > /tmp/.tmpf
+    cat /tmp/.tmpf > /etc/nginx/sites-available/default
+    kill -HUP `cat /var/run/nginx.pid`
+  fi
+else
+  npm run start
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -39,6 +39,7 @@ if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   cat /etc/nginx/nginx.conf|sed 's/access_log .var.log.nginx.access.log/access_log \/dev\/stdout/'| \
       sed 's/error_log .var.log.nginx.error.log/error_log \/dev\/stdout/' > /tmp/.tmpf
   cat /tmp/.tmpf > /etc/nginx/nginx.conf
+  echo "Serving content via nginx..."
   nginx -g 'daemon off;'
 else
   # Developer entrypoint:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,14 +32,14 @@ if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
   #
   npm install
   npm run build
-  ls -l dist
-  mv /var/www/html /var/www/prev-html
+  mv /var/www/html /var/www/dist-html
   ln -s /app/dist /var/www/html
   cat /etc/nginx/sites-available/default | sed 's/listen 80 default_server/listen 8001 default_server/' > /tmp/.tmpf
   cat /tmp/.tmpf > /etc/nginx/sites-available/default
+  cat /etc/nginx/nginx.conf|sed 's/access_log .var.log.nginx.access.log/access_log \/dev\/stdout/'| \
+      sed 's/error_log .var.log.nginx.error.log/error_log \/dev\/stdout/' > /tmp/.tmpf
+  cat /tmp/.tmpf > /etc/nginx/nginx.conf
   nginx -g 'daemon off;'
-  # add a post-exit sleep for debugging
-  sleep 3600
 else
   # Developer entrypoint:
   #

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,7 +37,7 @@ if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
     ln -s /app/dist /var/www/html
     cat /etc/nginx/sites-available/default | sed 's/listen 80 default_server/listen 8001 default_server/' > /tmp/.tmpf
     cat /tmp/.tmpf > /etc/nginx/sites-available/default
-    kill -HUP `cat /var/run/nginx.pid`
+    nginx -g 'daemon off;'
   fi
 else
   npm run start

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,15 +22,16 @@ else
     cp config.js.example config.js
 fi
 
-npm install
-# npm run test:lint
-# npm run test
 
 # NOTE: for a production environment (QA, Live) we serve content
 # via separate web server (nginx). Otherwise, run in development
 # mode directly.
 #
 if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
+  # Production entrypoint
+  if [ ! -d dist ]; then
+    npm run build
+  fi
   # this is a minimal node runtime, without most utilities.  compensate :)
   if [ -f /var/www/html/index.nginx-debian.html ]; then
     mv /var/www/html /var/www/prev-html
@@ -40,5 +41,10 @@ if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
     nginx -g 'daemon off;'
   fi
 else
+  # Developer entrypoint:
+  #
+  npm install
+  # npm run test:lint
+  # npm run test
   npm run start
 fi


### PR DESCRIPTION
This change alters check-search deployment to perform a production build, and then serve the generated dist/ content via Nginx.

Change should only affect QA and Live deployments. Developer builds will run npm directly as usual.