### PR TITLE
DEVOPS-216 Clear the CloudFlare cache for root document and config.js

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-search --image qa-check-search $ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA --exclusive-env -e qa-check-search DEPLOY_ENV qa -e qa-check-search AWS_DEFAULT_REGION $AWS_DEFAULT_REGION --timeout 1800 
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA"
+    - bash scripts/clear-cf-cache.sh qa
   only:
     - develop
 
@@ -82,5 +83,6 @@ deploy_live:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-search --image live-check-search $ECR_API_BASE_URL/live/check/search:$CI_COMMIT_SHA --exclusive-env -e live-check-search DEPLOY_ENV live -e live-check-search AWS_DEFAULT_REGION $AWS_DEFAULT_REGION --timeout 1800
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/search:$CI_COMMIT_SHA"
+    - bash scripts/clear-cf-cache.sh live
   only:
     - main

--- a/scripts/clear-cf-cache.sh
+++ b/scripts/clear-cf-cache.sh
@@ -17,3 +17,5 @@ elif [[ "$1" == "live" ]]; then
 else
     echo "Invalid environment given. Must be qa or live."
 fi
+
+exit 0

--- a/scripts/clear-cf-cache.sh
+++ b/scripts/clear-cf-cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [ "$#" -ne 1 ] ; then
+    echo "Missing required environment argument. Must be qa or live."
+    exit 0
+fi
+
+if [[ "$1" == "qa" ]]; then
+    echo "Clearing QA check-search cache at CloudFlare..."
+    curl --fail --output "/dev/null" --silent --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+        -H "Authorization: Bearer ${CF_CACHE_TOKEN}" -H "Content-Type: application/json" \
+        --data '{"files":["https://qa-search.checkmedia.org/","https://qa-search.checkmedia.org/config.js"]}'
+elif [[ "$1" == "live" ]]; then
+    echo "Clearing Live check-search cache at CloudFlare..."
+    curl --fail --output "/dev/null" --silent --show-error -X POST "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+        -H "Authorization: Bearer ${CF_CACHE_TOKEN}" -H "Content-Type: application/json" \
+        --data '{"files":["https://search.checkmedia.org/","https://search.checkmedia.org/config.js"]}'
+else
+    echo "Invalid environment given. Must be qa or live."
+fi


### PR DESCRIPTION
As per DEVOPS-216 Clear the CloudFlare cache for root document and config.js when deploying to QA or Live.