### PR TITLE
Fix CF cache clear script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-qa  qa-check-search --image qa-check-search $ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA --exclusive-env -e qa-check-search DEPLOY_ENV qa -e qa-check-search AWS_DEFAULT_REGION $AWS_DEFAULT_REGION --timeout 1800 
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/search:$CI_COMMIT_SHA"
-    - bash scripts/clear-cf-cache.sh qa
+    - sh scripts/clear-cf-cache.sh qa
   only:
     - develop
 
@@ -83,6 +83,6 @@ deploy_live:
     - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-check-search --image live-check-search $ECR_API_BASE_URL/live/check/search:$CI_COMMIT_SHA --exclusive-env -e live-check-search DEPLOY_ENV live -e live-check-search AWS_DEFAULT_REGION $AWS_DEFAULT_REGION --timeout 1800
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/search:$CI_COMMIT_SHA"
-    - bash scripts/clear-cf-cache.sh live
+    - sh scripts/clear-cf-cache.sh live
   only:
     - main


### PR DESCRIPTION
When running in the Docker build environment we may have a minimal shell like busybox instead of bash available. Handle this accordingly in the CloudFlare cache clear script.